### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -19,6 +19,7 @@
 $.extend( $.fn, {
 
 	// https://jqueryvalidation.org/validate/
+	// NOTE: For all options that accept selectors, only CSS selectors are allowed. HTML strings are rejected for safety.
 	validate: function( options ) {
 
 		// If nothing is selected, return nothing; can't chain anyway
@@ -683,8 +684,18 @@ $.extend( $.validator, {
 			} );
 		},
 
+		// Accepts a DOM element or a selector string. If a string, only treat as a CSS selector, never as HTML.
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			if (typeof selector === "string") {
+				// Prevent HTML interpretation by rejecting strings starting with "<"
+				if (selector.trim().charAt(0) === "<") {
+					throw new Error("Unsafe selector passed to clean: HTML is not allowed.");
+				}
+				// Use .find() on the current form to ensure only CSS selectors are used
+				return $(this.currentForm).find(selector)[0];
+			}
+			// If it's a DOM element or jQuery object, return the first element
+			return $(selector)[0];
 		},
 
 		errors: function() {
@@ -1069,7 +1080,15 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			if (typeof element === "string") {
+				// Prevent HTML interpretation by rejecting strings starting with "<"
+				if (element.trim().charAt(0) === "<") {
+					throw new Error("Unsafe selector passed to validationTargetFor: HTML is not allowed.");
+				}
+				// Use .find() on the current form to ensure only CSS selectors are used
+				return $(this.currentForm).find(element).not(this.settings.ignore)[0];
+			}
+			return $(element).not(this.settings.ignore)[0];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/4](https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/4)

To fix the problem, we need to ensure that the plugin never passes untrusted strings to the jQuery `$()` constructor in a way that could be interpreted as HTML. Specifically, in the `clean` and `validationTargetFor` methods, we should check if the input is a DOM element or a selector string. If it's a string, we should ensure it cannot be interpreted as HTML (i.e., does not start with `<`). If it is, we should either reject it or treat it strictly as a selector using `.find()` on a known context (e.g., the form). Additionally, we should document in the plugin's API that options which accept selectors must not be HTML, or sanitize them before use.

The best fix is to update the `clean` method to only accept DOM elements or safe selector strings, and update `validationTargetFor` to use `.find()` if a string is passed, never passing raw strings to `$()` that could be interpreted as HTML. This change should be made in `src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js` in the definitions of `clean` and `validationTargetFor`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
