### PR TITLE
Unsafe jquery fix

### DIFF
--- a/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -683,8 +683,30 @@ $.extend( $.validator, {
 			} );
 		},
 
-		clean: function( selector ) {
-			return $( selector )[ 0 ];
+		clean: function (selector) {
+			// Prevent XSS: only allow DOM elements, jQuery objects, or safe selectors (not HTML)
+			if (selector && (selector.nodeType === 1 || selector.nodeType === 9)) {
+				// DOM element
+				return selector;
+			}
+			if (selector && selector.jquery) {
+				// jQuery object
+				return selector[0];
+			}
+			if (typeof selector === "string") {
+				// Disallow HTML input (string starting with "<")
+				if (/^\s*</.test(selector)) {
+					throw new Error("Unsafe selector passed to clean(): HTML input is not allowed.");
+				}
+				// Use find on the current form context if available
+				if (this.currentForm) {
+					return $(this.currentForm).find(selector)[0];
+				}
+				// Fallback: use as selector in document context
+				return $(selector)[0];
+			}
+			// Otherwise, return null
+			return null;
 		},
 
 		errors: function() {

--- a/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -705,7 +705,7 @@ $.extend( $.validator, {
 				// Fallback: use as selector in document context
 				return $(selector)[0];
 			}
-			// Otherwise, return null
+			// Otherwise, return null 
 			return null;
 		},
 

--- a/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -698,12 +698,9 @@ $.extend( $.validator, {
 				if (/^\s*</.test(selector)) {
 					throw new Error("Unsafe selector passed to clean(): HTML input is not allowed.");
 				}
-				// Use find on the current form context if available
-				if (this.currentForm) {
-					return $(this.currentForm).find(selector)[0];
-				}
-				// Fallback: use as selector in document context
-				return $(selector)[0];
+				// Always use .find() on a context to avoid XSS
+				var context = this.currentForm || document;
+				return $(context).find(selector)[0];
 			}
 			// Otherwise, return null 
 			return null;


### PR DESCRIPTION
To fix the problem, we need to ensure that the clean method does not allow jQuery to interpret a string starting with < as HTML, which would result in the creation of DOM elements and a potential XSS vulnerability. The best way to do this is to check if the selector is a string and, if so, ensure it is always treated as a selector, not as HTML. This can be done by using find on a context (such as the form) or by rejecting strings that start with <. Alternatively, if the input is a DOM element, it should be returned as-is.

The most robust fix is to update the clean method to:

    If selector is a DOM element or jQuery object, return the first element.
    If selector is a string, ensure it does not start with < (i.e., is not HTML), and use find on the current form context if available.
    Optionally, document that only valid CSS selectors or DOM elements are allowed.

This change should be made in src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js, specifically in the clean method (lines 686-688).