### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1088,7 +1088,12 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			// Ensure element is a DOM element before passing to jQuery to prevent XSS
+			if (element && element.nodeType === 1) {
+				return $( element ).not( this.settings.ignore )[ 0 ];
+			} else {
+				return undefined;
+			}
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/4](https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/4)

To fix the problem, we need to ensure that the `element` parameter in the `validationTargetFor` method is always a DOM element before passing it to the jQuery selector. If `element` is not a DOM element (i.e., it is a string or other type), we should either return `undefined` or throw an error, or attempt to resolve it to a DOM element in a safe way (e.g., using `document.getElementById` if it is a string and matches an ID). The safest and most compatible fix is to check if `element` is a DOM node (i.e., `element.nodeType === 1`), and only then pass it to jQuery. Otherwise, return `undefined` or handle as appropriate.

The change should be made in the `validationTargetFor` method in `src/WebApplication/wwwroot/lib/jquery-validation/dist/jquery.validate.js`, specifically at the line where `$(element)` is called. No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
