### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_intelligentlogging.yml
+++ b/.github/workflows/main_intelligentlogging.yml
@@ -38,6 +38,8 @@ jobs:
   deploy:
     runs-on: windows-latest
     needs: build
+    permissions:
+      contents: read # This is required for actions/download-artifact
     environment:
       name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/2](https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `deploy` job in `.github/workflows/main_intelligentlogging.yml`. This block should specify the least privileges required for the job. Since the `deploy` job downloads artifacts and deploys to Azure, it likely only needs `contents: read` (for downloading artifacts from the repository). If the job needs to write to issues or pull requests, those permissions can be added, but based on the provided steps, only `contents: read` is necessary. The change should be made directly under the `deploy:` job definition, similar to how it is done in the `build` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
