### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/1](https://github.com/DwaineDGIlmer/IntelligentLogging/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the root level of the workflow (before `jobs:`), setting `contents: read`. This will apply to all jobs in the workflow unless overridden. No changes to the steps or other functionality are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
